### PR TITLE
Yajl native alternative

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: ruby
+addons:
+  apt:
+    packages:
+    - libyajl2
 rvm:
   - 2.3.3
 before_install: gem install bundler -v 1.14.6

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 This gem will basically spare you the need to define your own callbacks (i.e. implement an actual JSON parser using `start_object`, `end_object`, `key`, `value`, etc.).
 
 
-*If you're new to this:*
+#### If you're new to this
 
 Streaming is useful for
 - big files that do not fit in the memory (or you'd rather avoid the risk)
@@ -21,11 +21,13 @@ Streaming is useful for
 
 This gem is aimed at making streaming as easy and convenient as possible.
 
-*Performance:*
+#### Pure or native JSON parser
 
-The gem uses JSON::Stream's events in the background. It was chosen because it's a pure Ruby parser.
-A similar implementation can be done using the ~10 times faster Yajl::FFI gem that is dependent on the native YAJL library.
-I did not measure the performance of my implementation on top of these libraries.
+By default JSON::Stream is used to generate events from JSON input. It was chosen because it's a pure Ruby parser. However, if you include `event_generator: :native` and ensure the Gem [Yajl::FFI](https://github.com/dgraham/yajl-ffi) and its native lib is available, that will be used instead:
+```ruby
+Json::Streamer.parser(file_io: File.open('...'), event_generator: :native)
+```
+With YAJL::FFI::Parser as event generator, `json-streamer` is around 2-5 times faster.
 
 ## Installation
 
@@ -42,6 +44,19 @@ And then execute:
 Or install it yourself as:
 
     $ gem install json-streamer
+
+If you want to use Yajl:
+```ruby
+gem 'yajl-ffi'
+```
+
+Then install native libs, on MacOS X
+
+    $ brew install yajl
+
+Or, on Ubuntu
+
+    $ audo apt-get install libyajl2
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ This gem is aimed at making streaming as easy and convenient as possible.
 
 #### Pure or native JSON parser
 
-By default JSON::Stream is used to generate events from JSON input. It was chosen because it's a pure Ruby parser. However, if you include `event_generator: :native` and ensure the Gem [Yajl::FFI](https://github.com/dgraham/yajl-ffi) and its native lib is available, that will be used instead:
+By default JSON::Stream is used to generate events from JSON input. It was chosen because it's a pure Ruby parser. However, you can pass an instance of  [Yajl::FFI::Parser](https://github.com/dgraham/yajl-ffi) which is backed by the Yajl C library, to use instead:
 ```ruby
-Json::Streamer.parser(file_io: File.open('...'), event_generator: :native)
+require 'yajl/ffi'
+Json::Streamer.parser(file_io: File.open('...'), event_generator: Yajl::FFI::Parser.new)
 ```
-With YAJL::FFI::Parser as event generator, `json-streamer` is around 2-5 times faster.
+With YAJL::FFI::Parser as event generator, `json-streamer` is around 2-5 times faster. This requires the Yajl C library to be available on the platform, see below.
 
 ## Installation
 

--- a/json-streamer.gemspec
+++ b/json-streamer.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-bundler"
   spec.add_development_dependency "guard-rspec"
+  spec.add_development_dependency "yajl-ffi"
 
   spec.add_dependency "json-stream"
 end

--- a/lib/json/streamer.rb
+++ b/lib/json/streamer.rb
@@ -2,7 +2,7 @@ require_relative "streamer/json_streamer"
 
 module Json
   module Streamer
-    def self.parser(file_io: nil, chunk_size: 1000, event_generator: :pure)
+    def self.parser(file_io: nil, chunk_size: 1000, event_generator: :default)
       JsonStreamer.new(file_io, chunk_size, event_generator)
     end
   end

--- a/lib/json/streamer.rb
+++ b/lib/json/streamer.rb
@@ -2,8 +2,8 @@ require_relative "streamer/json_streamer"
 
 module Json
   module Streamer
-    def self.parser(file_io: nil, chunk_size: 1000)
-      JsonStreamer.new(file_io, chunk_size)
+    def self.parser(file_io: nil, chunk_size: 1000, event_generator: :pure)
+      JsonStreamer.new(file_io, chunk_size, event_generator)
     end
   end
 end

--- a/lib/json/streamer/json_streamer.rb
+++ b/lib/json/streamer/json_streamer.rb
@@ -1,5 +1,3 @@
-require "json/stream"
-
 require_relative 'conditions'
 require_relative 'parser'
 
@@ -9,8 +7,8 @@ module Json
 
       attr_reader :parser
 
-      def initialize(file_io = nil, chunk_size = 1000)
-        @event_generator = JSON::Stream::Parser.new
+      def initialize(file_io = nil, chunk_size = 1000, event_generator = :pure)
+        @event_generator = make_event_generator(event_generator)
 
         @file_io = file_io
         @chunk_size = chunk_size
@@ -52,6 +50,19 @@ module Json
 
       def process_io
         @file_io.each(@chunk_size) { |chunk| parser << chunk } if @file_io
+      end
+
+      def make_event_generator(generator_type)
+        case generator_type
+        when :pure
+          require 'json/stream'
+          JSON::Stream::Parser.new
+        when :native
+          require "yajl/ffi"
+          Yajl::FFI::Parser.new
+        else
+          generator_type
+        end
       end
     end
   end

--- a/lib/json/streamer/json_streamer.rb
+++ b/lib/json/streamer/json_streamer.rb
@@ -7,7 +7,7 @@ module Json
 
       attr_reader :parser
 
-      def initialize(file_io = nil, chunk_size = 1000, event_generator = :pure)
+      def initialize(file_io = nil, chunk_size = 1000, event_generator = :default)
         @event_generator = make_event_generator(event_generator)
 
         @file_io = file_io
@@ -52,16 +52,12 @@ module Json
         @file_io.each(@chunk_size) { |chunk| parser << chunk } if @file_io
       end
 
-      def make_event_generator(generator_type)
-        case generator_type
-        when :pure
+      def make_event_generator(event_generator)
+        if event_generator == :default
           require 'json/stream'
           JSON::Stream::Parser.new
-        when :native
-          require "yajl/ffi"
-          Yajl::FFI::Parser.new
         else
-          generator_type
+          event_generator
         end
       end
     end

--- a/spec/json/streamer/json_streamer_spec.rb
+++ b/spec/json/streamer/json_streamer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Json::Streamer::JsonStreamer do
+RSpec.shared_examples 'streamer tests' do
   before do
     if DEBUG
       highlight('INPUT') do
@@ -37,7 +37,7 @@ RSpec.describe Json::Streamer::JsonStreamer do
     let(:json) { JSON.generate(hash) }
     let(:json_file_mock) { StringIO.new(json) }
     let(:yielded_objects) { [] }
-    let(:streamer) { Json::Streamer::JsonStreamer.new(json_file_mock, chunk_size) }
+    let(:streamer) { Json::Streamer::JsonStreamer.new(json_file_mock, chunk_size, parser_type) }
 
     before do
       streamer.get(params) do |object|
@@ -359,5 +359,17 @@ RSpec.describe Json::Streamer::JsonStreamer do
         end
       end
     end
+  end
+end
+
+RSpec.describe Json::Streamer::JsonStreamer do
+  context 'using json/stream' do
+    let(:parser_type) { :pure }
+    it_behaves_like 'streamer tests'
+  end
+
+  context 'using yajl/ffi' do
+    let(:parser_type) { :native }
+    it_behaves_like 'streamer tests'
   end
 end

--- a/spec/json/streamer/json_streamer_spec.rb
+++ b/spec/json/streamer/json_streamer_spec.rb
@@ -37,7 +37,7 @@ RSpec.shared_examples 'streamer tests' do
     let(:json) { JSON.generate(hash) }
     let(:json_file_mock) { StringIO.new(json) }
     let(:yielded_objects) { [] }
-    let(:streamer) { Json::Streamer::JsonStreamer.new(json_file_mock, chunk_size, parser_type) }
+    let(:streamer) { Json::Streamer::JsonStreamer.new(json_file_mock, chunk_size, event_generator) }
 
     before do
       streamer.get(params) do |object|
@@ -364,12 +364,13 @@ end
 
 RSpec.describe Json::Streamer::JsonStreamer do
   context 'using json/stream' do
-    let(:parser_type) { :pure }
+    let(:event_generator) { :default }
     it_behaves_like 'streamer tests'
   end
 
   context 'using yajl/ffi' do
-    let(:parser_type) { :native }
+    require 'yajl/ffi'
+    let(:event_generator) { Yajl::FFI::Parser.new }
     it_behaves_like 'streamer tests'
   end
 end

--- a/spec/json/streamer_spec.rb
+++ b/spec/json/streamer_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe Json::Streamer do
       json_file_mock = StringIO.new(JSON.generate(hash))
       chunk_size = 10
 
-      streamer = Json::Streamer.parser(file_io: json_file_mock, chunk_size: chunk_size)
+      custom_generator = Object.new
+      streamer = Json::Streamer.parser(file_io: json_file_mock, chunk_size: chunk_size, event_generator: custom_generator)
 
       expect(streamer.instance_variable_get(:@file_io)).to eq(json_file_mock)
       expect(streamer.instance_variable_get(:@chunk_size)).to eq(chunk_size)
+      expect(streamer.instance_variable_get(:@event_generator)).to eq(custom_generator)
     end
   end
 end


### PR DESCRIPTION
Add additional argument to `Json::Streamer.parser(file_io: io, event_generator: :native)` that makes use of [Yajl::FFI](https://github.com/dgraham/yajl-ffi) as event generator which has an identical signature to `JSON::Stream`. This change also makes it possible to pass custom event generators to the parser.

Some simple benchmarking indicates that using `YAJL::FFI` makes `Json::Streamer::JsonStreamer` between 2-5 times faster when extracting objects from an array, i.e. a `[{...}, ...]`. E.g. when fed a 80 MBytes JSON with 40000 objects in one array:
```
             user     system      total        real
pure   142.240000   7.880000 150.120000 (154.627060)
native  72.250000  11.700000  83.950000 ( 85.759084)
```
When fed an 11 MBytes JSON with 40000 objects in one array:
```
pure   16.810000   0.080000  16.890000 ( 17.002056)
native  4.880000   0.050000   4.930000 (  4.962523)
```
Times are on `16.7.0 Darwin Kernel` with 2-core CPU with hyperthreading. 

Given the state of native and optional dependencies, I opted for the approach where the caller is responsible for providing both `YAJL::FFI` and its native lib. However, I still add it as a development dependency so that we can spec against it, which means that devs now need the native dependency as well.

I have not added specs for memory consumption as using the native variety seems to give less consistent results.